### PR TITLE
Fix message save/populate and profile lookup bugs

### DIFF
--- a/backend/controllers/MessageController.js
+++ b/backend/controllers/MessageController.js
@@ -10,7 +10,7 @@ exports.saveMessage = async (req, res) => {
     }
 
     const newMessage = await Message.create({
-      conversaationId: chatRoomId,
+      conversationId: chatRoomId,
       senderId,
       content: message,
     });
@@ -26,7 +26,7 @@ exports.getMessages = async (req, res) => {
     const { chatRoomId } = req.params;
 
     const messages = await Message.find({ conversationId: chatRoomId })
-      .populate("sender", "username email")
+      .populate("senderId", "username email")
       .sort({ createdAt: 1 });
 
     res.json(messages);
@@ -34,4 +34,3 @@ exports.getMessages = async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 };
-

--- a/backend/controllers/SignInContoller.js
+++ b/backend/controllers/SignInContoller.js
@@ -120,7 +120,7 @@ const verifyToken = (req, res, next) => {
 
 const getProfile = async (req, res) => {
   try {
-    const user = await User.findById(req.userId).select('-googleId');
+    const user = await User.findById(req.user.id).select('-googleId');
     res.json({
       success: true,
       user


### PR DESCRIPTION
### Motivation
- Ensure messages are persisted and queried using the correct field names and return the authenticated user's profile correctly after token verification.

### Description
- In `backend/controllers/MessageController.js` fixed a typo by writing the created document field as `conversationId` instead of `conversaationId` and updated the query populate to use `.populate("senderId", "username email")` to match the schema.
- In `backend/controllers/SignInContoller.js` updated the profile lookup to use the authenticated ID set by the token middleware via `req.user.id` instead of `req.userId`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980ef654d608331a467287761839698)